### PR TITLE
custom entry card

### DIFF
--- a/dev-test/index.html
+++ b/dev-test/index.html
@@ -153,6 +153,25 @@
         ) : null;
       }
     });
+    function formatDate(date){
+      if(date && date.toLocaleDateString) return date.toLocaleDateString('en')
+      return date.toString ? date.toString() : ''
+    }
+    function PostEntryCard(props){
+      const entry = props.entry;
+      const collection = props.collection;
+      const title = entry.getIn(['data', 'title']);
+      const date = entry.getIn(['data', 'date']);
+      const path = `#/collections/${collection.get('name')}/entries/${entry.get('slug')}`;
+      return (
+        h('div', {style: {flex: 1, minWidth: '100%'}},
+          h('a', {href: path}, [
+            h('h2', {key: 'title'}, title),
+            h('h3', {key: 'date'}, formatDate(date)),
+          ])
+        )
+      );
+    }
 
     const previewStyles = `
       html,
@@ -178,6 +197,7 @@
       }
     `;
 
+    CMS.registerEntryCard("posts", PostEntryCard);
     CMS.registerPreviewTemplate("posts", PostPreview);
     CMS.registerPreviewTemplate("general", GeneralPreview);
     CMS.registerPreviewTemplate("authors", AuthorsPreview);

--- a/packages/netlify-cms-core/src/components/Collection/Entries/EntryListing.js
+++ b/packages/netlify-cms-core/src/components/Collection/Entries/EntryListing.js
@@ -5,8 +5,9 @@ import styled from 'react-emotion';
 import Waypoint from 'react-waypoint';
 import { Map } from 'immutable';
 import { Cursor } from 'netlify-cms-lib-util/src';
+import { getEntryCard } from 'Lib/registry';
 import { selectFields, selectInferedField } from 'Reducers/collections';
-import EntryCard from './EntryCard';
+import DefaultEntryCard from './EntryCard';
 
 const CardsGrid = styled.ul`
   display: flex;
@@ -47,6 +48,8 @@ export default class EntryListing extends React.Component {
     const { collections, entries, publicFolder, viewStyle } = this.props;
     const inferedFields = this.inferFields(collections);
     const entryCardProps = { collection: collections, inferedFields, publicFolder, viewStyle };
+    const EntryCard = getEntryCard(collections.get('name')) || DefaultEntryCard;
+    console.log({ collectionName: collections.get('name') });
     return entries.map((entry, idx) => <EntryCard {...entryCardProps} entry={entry} key={idx} />);
   };
 
@@ -58,6 +61,7 @@ export default class EntryListing extends React.Component {
       const collectionLabel = collection.get('label');
       const inferedFields = this.inferFields(collection);
       const entryCardProps = { collection, entry, inferedFields, publicFolder, collectionLabel };
+      const EntryCard = getEntryCard(collectionName) || DefaultEntryCard;
       return <EntryCard {...entryCardProps} key={idx} />;
     });
   };

--- a/packages/netlify-cms-core/src/lib/registry.js
+++ b/packages/netlify-cms-core/src/lib/registry.js
@@ -12,6 +12,7 @@ const registry = {
   editorComponents: Map(),
   widgetValueSerializers: {},
   mediaLibraries: [],
+  entryCards: {},
 };
 
 export default {
@@ -30,6 +31,8 @@ export default {
   getBackend,
   registerMediaLibrary,
   getMediaLibrary,
+  registerEntryCard,
+  getEntryCard,
 };
 
 /**
@@ -125,4 +128,20 @@ export function registerMediaLibrary(mediaLibrary, options) {
 
 export function getMediaLibrary(name) {
   return registry.mediaLibraries.find(ml => ml.name === name);
+}
+
+/**
+ * EntryCard component
+ */
+export function registerEntryCard(collectionName, Component) {
+  if (!collectionName || !Component) {
+    console.error(
+      "EntryCard parameters invalid. example: CMS.registerEntryCard('collection-name', Component)",
+    );
+  }
+  registry.entryCards[collectionName] = Component;
+}
+
+export function getEntryCard(collectionName) {
+  return registry.entryCards[collectionName];
 }

--- a/website/content/docs/custom-card.md
+++ b/website/content/docs/custom-card.md
@@ -1,0 +1,64 @@
+---
+title: Creating Custom Entry Card
+weight: 25
+group: guides
+---
+
+The NetlifyCMS exposes a `window.CMS` global object that you can use to register custom widgets, previews, and editor plugins. The same object is also the default export if you import Netify CMS as an npm module. The available entry card extension methods are:
+
+* **registerEntryCard:** registers a custom card, for a collection.
+* **getEntryCard:** get a custom entry card by it's collection name.
+
+### Writing React Components inline
+
+The `registerEntryCard` requires you to provide a React component. If you have a build process in place for your project, it is possible to integrate with this build process.
+
+However, although possible, it may be cumbersome or even impractical to add a React build phase. For this reason, NetlifyCMS exposes two constructs globally to allow you to create components inline: ‘createClass’ and ‘h’ (alias for React.createElement).
+
+## `registerEntryCard`
+
+Register a custom widget.
+
+```js
+// Using global window object
+CMS.registerEntryCard(collectionName, component);
+
+// Using npm module import
+import CMS from 'netlify-cms';
+CMS.registerEntryCard(collectionName, component);
+```
+
+**Params:**
+
+| Param            | Type                                          | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| ---------------- | --------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `collectionName` | `String`                                      | the collection name (set in config.yml) for which this card will be rendered.                                                                                                                                                                                                                                                                                                                                                                                        |
+| `component`      | `React.Component` or `"functional component"` | React component that renders the entry card, receives the following props: <ul><li>**collection**: &lt;`Immutable.Map`&gt; contains the config set for this collection (in config.yml)</li><li>**entry**: &lt;`Immutable.Map`&gt; contains the entry data (frontmatter and body, when markdown)</li><li>**publicFolder**: &lt;`String`&gt; the publicFolder set in config.yml</li><li>**viewStyle**: &lt;`Enum`&gt; `VIEW_STYLE_LIST` OR `VIEW_STYLE_GRID`</li></ul> |
+
+
+**Example:**
+
+```html
+<script src="https://unpkg.com/netlify-cms@^2.0.0/dist/netlify-cms.js"></script>
+<script>
+  function formatDate(date) {
+    if(date && date.toLocaleDateString) return date.toLocaleDateString('en');
+    return date.toString ? date.toString() : '';
+  }
+  function PostEntryCard({entry, collection}) {
+    const title = entry.getIn(['data', 'title']);
+    const date = entry.getIn(['data', 'date']);
+    const path = `#/collections/${collection.get('name')}/entries/${entry.get('slug')}`;
+    return (
+      h('div', {style: {flex: 1, minWidth: '100%'}},
+        h('a', {href: path}, [
+          h('h2', {key: 'title'}, title),
+          h('h3', {key: 'date'}, formatDate(date)),
+        ])
+      )
+    );
+  }
+
+  CMS.registerEntryCard('posts', PostEntryCard);
+</script>
+```


### PR DESCRIPTION
## todo
- [x] implementation
- [x] bare-bones testing
- [x] alpha quality docs

## quick example

```jsx
import { Link as ReactRouterLink } from 'react-router-dom'
import CMS from 'netlify-cms'

const formatDate = date => {
  if (date && date.toLocaleDateString) return date.toLocaleDateString('en')
  return date.toString ? date.toString() : ''
}

const PostEntryCard = ({entry, collection}) => {
  const title = entry.getIn(['data', 'title'])
  const date = entry.getIn(['data', 'date'])
  const slug = entry.get('slug')
  const path = `/collections/${collection.get('name')}/entries/${slug}`
  return (
    <div style={{flex: 1, minWidth: '100%'}}>
      <ReactRouterLink to={path}>
        <h2>{title}</h2>
        <h3>{formatDate(date)}</h3>
      </ReactRouterLink>
    </div>
  )
}

CMS.registerEntryCard('posts', PostEntryCard)
```

## proper implementation
refer to the [default `EntryCard`](https://github.com/campus-online/cms/blob/master/packages/netlify-cms-core/src/components/Collection/Entries/EntryCard.js) for implementing a pretty one.