### PR TITLE
sanitize markdown

### DIFF
--- a/packages/netlify-cms-widget-markdown/src/serializers/__tests__/slate.spec.js
+++ b/packages/netlify-cms-widget-markdown/src/serializers/__tests__/slate.spec.js
@@ -34,3 +34,57 @@ describe('slate', () => {
     expect(process('<span>*</span>')).toEqual('<span>*</span>');
   });
 });
+
+it('should not produce invalid markdown when a styled block has trailing whitespace', () => {
+  const slateAst = {
+    object: 'block',
+    type: 'root',
+    nodes: [
+      {
+        object: 'block',
+        type: 'paragraph',
+        nodes: [
+          {
+            object: 'text',
+            data: undefined,
+            leaves: [
+              {
+                text: 'foo ', // <--
+                marks: [{ type: 'bold' }],
+              },
+            ],
+          },
+          { object: 'text', data: undefined, leaves: [{ text: 'bar' }] },
+        ],
+      },
+    ],
+  };
+  expect(slateToMarkdown(slateAst)).toEqual('**foo** bar');
+});
+
+it('should not produce invalid markdown when a styled block has leading whitespace', () => {
+  const slateAst = {
+    object: 'block',
+    type: 'root',
+    nodes: [
+      {
+        object: 'block',
+        type: 'paragraph',
+        nodes: [
+          { object: 'text', data: undefined, leaves: [{ text: 'foo' }] },
+          {
+            object: 'text',
+            data: undefined,
+            leaves: [
+              {
+                text: ' bar', // <--
+                marks: [{ type: 'bold' }],
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+  expect(slateToMarkdown(slateAst)).toEqual('foo **bar**');
+});

--- a/packages/netlify-cms-widget-markdown/src/serializers/index.js
+++ b/packages/netlify-cms-widget-markdown/src/serializers/index.js
@@ -136,7 +136,8 @@ export const remarkToMarkdown = obj => {
   const markdown = unified()
     .use(remarkToMarkdownPlugin, remarkToMarkdownPluginOpts)
     .use(remarkAllowAllText)
-    .stringify(processedMdast);
+    .stringify(processedMdast)
+    .replace(/\r+/g, '');
 
   /**
    * Return markdown with trailing whitespace removed.


### PR DESCRIPTION
`upstream`: https://github.com/netlify/netlify-cms/pull/1517

needs further testing, found some edge cases.

**update**: too many edge cases. maybe reimplement later using `prosemirror`.

<sup>it seems there's no dedicated WYSIWYG markdown editor for the web.
needs further research<sup>